### PR TITLE
Fixed: WPF workaround for importing extensions does not always work

### DIFF
--- a/Source/MSBuild.Sdk.Extras/Build/Workarounds.props
+++ b/Source/MSBuild.Sdk.Extras/Build/Workarounds.props
@@ -39,6 +39,7 @@
   <PropertyGroup Condition="'$(_SdkOriginalProjectName)' != ''">
     <_SdkOriginalProjectFile>$(_SdkOriginalProjectName)$(MSBuildProjectExtension)</_SdkOriginalProjectFile>
     <_SdkOriginalProjectExtensionsPath Condition="$(MSBuildProjectExtensionsPath.Contains('$(MSBuildProjectName)'))">$(MSBuildProjectExtensionsPath.Replace('$(MSBuildProjectName)', '$(_SdkOriginalProjectName)'))</_SdkOriginalProjectExtensionsPath>
+    <_SdkOriginalProjectExtensionsPath Condition=" '$(_SdkOriginalProjectExtensionsPath)' == '' ">$(MSBuildProjectExtensionsPath)</_SdkOriginalProjectExtensionsPath>
     <RestoreOutputPath>$(_SdkOriginalProjectExtensionsPath)</RestoreOutputPath>
   </PropertyGroup>
 


### PR DESCRIPTION
The issue happens when BaseIntermediateOutputPath is overridden, thus
MSBuildProjectExtensionsPath gets assigned without generated suffix
even in *_wpftmp.*proj file.
Since _SdkOriginalProjectExtensionsPath didn't have a fallback value -
that prevented importing project extensions. This change adds the
fallback, making it effectively like "if there's a suffix - remove it,
otherwise use as is".