### PR TITLE
Major per-RuntimeIdentifier build refactoring

### DIFF
--- a/MSBuild.Sdk.Extras.sln
+++ b/MSBuild.Sdk.Extras.sln
@@ -36,7 +36,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{19A683CB
 		Tools\MSBuild.Packaging.targets = Tools\MSBuild.Packaging.targets
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UwpClassLibrary", "Tests\UwpClassLibrary\UwpClassLibrary.csproj", "{B7617E50-4107-4C19-BDCF-012CCDB22FB0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UwpClassLibrary", "Tests\UwpClassLibrary\UwpClassLibrary.csproj", "{B7617E50-4107-4C19-BDCF-012CCDB22FB0}"
+EndProject
+Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = "ClasslibPackTests", "Tests\ClasslibPackTests.msbuildproj", "{8DB76FFF-B050-433B-B478-1FC44DB9DF6B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -80,6 +82,10 @@ Global
 		{B7617E50-4107-4C19-BDCF-012CCDB22FB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B7617E50-4107-4C19-BDCF-012CCDB22FB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B7617E50-4107-4C19-BDCF-012CCDB22FB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8DB76FFF-B050-433B-B478-1FC44DB9DF6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DB76FFF-B050-433B-B478-1FC44DB9DF6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8DB76FFF-B050-433B-B478-1FC44DB9DF6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8DB76FFF-B050-433B-B478-1FC44DB9DF6B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -94,6 +100,7 @@ Global
 		{C2EE161F-0521-47F7-BE2D-0B55CA8B3C53} = {26026DB4-DD68-43BF-8858-15AD2016C0B2}
 		{19A683CB-8C5D-480B-8D60-30F28DA40660} = {8647C74A-083C-4EAF-B9B0-2172D4A27BFC}
 		{B7617E50-4107-4C19-BDCF-012CCDB22FB0} = {26026DB4-DD68-43BF-8858-15AD2016C0B2}
+		{8DB76FFF-B050-433B-B478-1FC44DB9DF6B} = {26026DB4-DD68-43BF-8858-15AD2016C0B2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {93349570-79D8-4F89-8E78-C66401620727}

--- a/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
@@ -2,76 +2,97 @@
 
   <PropertyGroup>
     <MSBuildAllProjects Condition=" '$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0' ">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <ExtrasIncludeDefaultProjectBuildOutputInPackTarget Condition="'$(ExtrasIncludeDefaultProjectBuildOutputInPackTarget)' == ''">_SdkIncludeDefaultProjectBuildOutputInPackImpl</ExtrasIncludeDefaultProjectBuildOutputInPackTarget>
   </PropertyGroup>
+
 
   <Target Name="_SdkGetRidsPerTargetFramework" Returns="@(_SdkRuntimeId)">
 
-    <PropertyGroup>
-      <ExtrasBuildEachRuntimeIdentifier Condition="'$(ExtrasBuildEachRuntimeIdentifier)' == ''">false</ExtrasBuildEachRuntimeIdentifier>
-    </PropertyGroup>
-
     <ItemGroup>
-      <_SdkRuntimeIds Include="$(RuntimeIdentifiers)" Condition="'$(RuntimeIdentifiers)' != '' and '$(ExtrasBuildEachRuntimeIdentifier)' == 'true' " TargetFramework="$(TargetFramework)"  />
+      <_SdkRuntimeIds Include="$(RuntimeIdentifiers)" Condition="'$(RuntimeIdentifiers)' != '' and '$(ExtrasBuildEachRuntimeIdentifier)' == 'true' " TargetFramework="$(TargetFramework)" />
 
-      <_SdkRuntimeId Include="@(_SdkRuntimeIds->'%(TargetFramework)')" Rid="%(_SdkRuntimeIds.Identity)"  />    
-      <_SdkRuntimeId Include="$(TargetFramework)" Condition="'$(ExtrasBuildEachRuntimeIdentifier)' == 'false'"  />
+      <_SdkRuntimeId Include="@(_SdkRuntimeIds->'%(TargetFramework)')" Rid="%(_SdkRuntimeIds.Identity)" />
+      <_SdkRuntimeId Include="$(TargetFramework)" Condition="'$(ExtrasBuildEachRuntimeIdentifier)' != 'true'" />
     </ItemGroup>
+
   </Target>
 
 
-
-  <Target Name="_ComputeTargetFrameworkItems" Returns="@(InnerOutput)">
+  <Target Name="_SdkTargetFrameworkNormalizedFromComputeTargetFrameworkItems">
     <ItemGroup>
       <_TargetFramework Include="$(TargetFrameworks)" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <_InnerBuildProjects Include="$(MSBuildProjectFile)">
-        <AdditionalProperties>TargetFramework=%(_TargetFramework.Identity)</AdditionalProperties>
-      </_InnerBuildProjects>
-    </ItemGroup>
-
-    <MSBuild Projects="@(_InnerBuildProjects)"
-             BuildInParallel="$(BuildInParallel)"
-             Targets="_SdkGetRidsPerTargetFramework">
-      <Output ItemName="_SdkTargetsWithRids" TaskParameter="TargetOutputs"  />
-    </MSBuild>
-
-    <ItemGroup>
-      <_InnerBuildProjects Remove="@(_InnerBuildProjects)" />
-      <_InnerBuildProjects Include="$(MSBuildProjectFile)">
-        <AdditionalProperties Condition="'%(_SdkTargetsWithRids.Rid)' != ''" >TargetFramework=%(_SdkTargetsWithRids.Identity);RuntimeIdentifier=%(_SdkTargetsWithRids.Rid)</AdditionalProperties>
-        <AdditionalProperties Condition="'%(_SdkTargetsWithRids.Rid)' == ''" >TargetFramework=%(_SdkTargetsWithRids.Identity)</AdditionalProperties>
-      </_InnerBuildProjects>
+      <!-- Make normalization explicit: Trim; Deduplicate by keeping first occurrence, case insensitive -->
+      <_TargetFrameworkNormalized Include="@(_TargetFramework->Trim()->Distinct())" />
     </ItemGroup>
   </Target>
 
 
+  <!-- Implicit DependsOnTargets="_GetTargetFrameworksOutput" -->
+  <Target Name="_SdkTargetFrameworkNormalizedFromGetTargetFrameworksOutput">
+    <ItemGroup>
+      <_TargetFrameworkNormalized Include="@(_TargetFrameworks)" />
+    </ItemGroup>
+  </Target>
 
-  <Target Name="_WalkEachTargetPerFramework">
-    <MSBuild Projects="$(MSBuildProjectFile)"
+
+  <Target Name="_SdkPrepareProjectFlavorMatrix"
+          DependsOnTargets="$(_SdkPrepareProjectFlavorMatrixDependsOn)">
+
+    <ItemGroup>
+      <_SdkProjectFlavorMatrixItem Include="$(MSBuildProjectFullPath)">
+        <SetTargetFramework>TargetFramework=%(_TargetFrameworkNormalized.Identity)</SetTargetFramework>
+        <SetRuntimeIdentifier />
+      </_SdkProjectFlavorMatrixItem>
+    </ItemGroup>
+
+    <MSBuild Projects="@(_SdkProjectFlavorMatrixItem)"
              BuildInParallel="$(BuildInParallel)"
-             Properties="TargetFramework=%(_TargetFrameworks.Identity)"
+             Properties="%(_SdkProjectFlavorMatrixItem.SetTargetFramework)"
              Targets="_SdkGetRidsPerTargetFramework">
-      <Output ItemName="_SdkTargetsWithRids" TaskParameter="TargetOutputs"  />
+      <Output ItemName="_SdkProjectFlavorMatrixItemStaging" TaskParameter="TargetOutputs" />
     </MSBuild>
 
+    <ItemGroup>
+      <_SdkProjectFlavorMatrixItem Remove="@(_SdkProjectFlavorMatrixItem)" />
+      <_SdkProjectFlavorMatrixItem Include="@(_SdkProjectFlavorMatrixItemStaging->'%(OriginalItemSpec)')" KeepMetadata="TargetFramework;SetTargetFramework;Rid;SetRuntimeIdentifier" />
+      <_SdkProjectFlavorMatrixItemStaging Remove="@(_SdkProjectFlavorMatrixItemStaging)" />
+      <_SdkProjectFlavorMatrixItem Update="@(_SdkProjectFlavorMatrixItem)">
+        <SetRuntimeIdentifier Condition="'%(_SdkProjectFlavorMatrixItem.Rid)' != ''">RuntimeIdentifier=%(_SdkProjectFlavorMatrixItem.Rid)</SetRuntimeIdentifier>
+      </_SdkProjectFlavorMatrixItem>
+    </ItemGroup>
+
+  </Target>
+
+
+  <!-- Microsoft.Common.CrossTargeting.targets -> _ComputeTargetFrameworkItems -->
+  <!-- One intentional diff in target signature: removal of Returns="@(InnerOutput)" -->
+  <!-- Rationale: it's not produced by _ComputeTargetFrameworkItems, most likely a result of copy-paste -->
+  <Target Name="_ComputeTargetFrameworkItems"
+          DependsOnTargets="_SdkTargetFrameworkNormalizedFromComputeTargetFrameworkItems;_SdkPrepareProjectFlavorMatrix">
+
+    <ItemGroup>
+      <_InnerBuildProjects Include="@(_SdkProjectFlavorMatrixItem)" KeepMetadata="FakeProperty">
+        <AdditionalProperties Condition="'%(SetRuntimeIdentifier)' != ''">%(SetTargetFramework);%(SetRuntimeIdentifier)</AdditionalProperties>
+        <AdditionalProperties Condition="'%(SetRuntimeIdentifier)' == ''">%(SetTargetFramework)</AdditionalProperties>
+      </_InnerBuildProjects>
+    </ItemGroup>
+
+  </Target>
+
+
+  <Target Name="_WalkEachTargetPerFrameworkCore"
+          DependsOnTargets="_SdkTargetFrameworkNormalizedFromGetTargetFrameworksOutput;_SdkPrepareProjectFlavorMatrix;$(_WalkEachTargetPerFrameworkCoreDependsOn)">
+
+    <PropertyGroup>
+      <ExtrasRidSpecificOutputNoKeepMetadata Condition="'$(ExtrasRidSpecificOutputNoKeepMetadata)' == ''">false</ExtrasRidSpecificOutputNoKeepMetadata>
+      <ExtrasRidSpecificOutputKeepMetadata Condition="'$(ExtrasRidSpecificOutputKeepMetadata)' == '' and '$(ExtrasRidSpecificOutputNoKeepMetadata)' == 'false'">TargetFramework;Rid</ExtrasRidSpecificOutputKeepMetadata>
+    </PropertyGroup>
+
     <MSBuild
-      Condition="'$(IncludeBuildOutput)' == 'true' and '%(_SdkTargetsWithRids.Rid)' != ''"
-      Projects="$(MSBuildProjectFullPath)"
+      Condition="'$(IncludeBuildOutput)' == 'true'"
+      Projects="@(_SdkProjectFlavorMatrixItem)"
       Targets="_SdkGetBuildOutputFilesWithTfm"
-      Properties="TargetFramework=%(_SdkTargetsWithRids.Identity);RuntimeIdentifier=%(_SdkTargetsWithRids.Rid)">
-
-      <Output
-          TaskParameter="TargetOutputs"
-          ItemName="_BuildOutputInPackageWithRid" />
-    </MSBuild>
-
-    <MSBuild
-      Condition="'$(IncludeBuildOutput)' == 'true' and '%(_SdkTargetsWithRids.Rid)' == ''"
-      Projects="$(MSBuildProjectFullPath)"
-      Targets="_GetBuildOutputFilesWithTfm"
-      Properties="TargetFramework=%(_SdkTargetsWithRids.Identity);">
+      Properties="%(_SdkProjectFlavorMatrixItem.SetTargetFramework); %(_SdkProjectFlavorMatrixItem.SetRuntimeIdentifier)">
 
       <Output
         TaskParameter="TargetOutputs"
@@ -79,10 +100,10 @@
     </MSBuild>
 
     <MSBuild
-      Condition="'$(TargetsForTfmSpecificContentInPackage)' != '' and '%(_SdkTargetsWithRids.Rid)' != ''"
-      Projects="$(MSBuildProjectFullPath)"
+      Condition="'$(TargetsForTfmSpecificContentInPackage)' != ''"
+      Projects="@(_SdkProjectFlavorMatrixItem)"
       Targets="_GetTfmSpecificContentForPackage"
-      Properties="TargetFramework=%(_SdkTargetsWithRids.Identity);RuntimeIdentifier=%(_SdkTargetsWithRids.Rid)">
+      Properties="%(_SdkProjectFlavorMatrixItem.SetTargetFramework); %(_SdkProjectFlavorMatrixItem.SetRuntimeIdentifier)">
 
       <Output
           TaskParameter="TargetOutputs"
@@ -90,32 +111,10 @@
     </MSBuild>
 
     <MSBuild
-      Condition="'$(TargetsForTfmSpecificContentInPackage)' != '' and '%(_SdkTargetsWithRids.Rid)' == ''"
-      Projects="$(MSBuildProjectFullPath)"
-      Targets="_GetTfmSpecificContentForPackage"
-      Properties="TargetFramework=%(_SdkTargetsWithRids.Identity);">
-
-      <Output
-        TaskParameter="TargetOutputs"
-        ItemName="_PackageFiles"/>
-    </MSBuild>
-
-    <MSBuild
-      Condition="'$(IncludeBuildOutput)' == 'true' and '%(_SdkTargetsWithRids.Rid)' != ''"
-      Projects="$(MSBuildProjectFullPath)"
+      Condition="'$(IncludeBuildOutput)' == 'true'"
+      Projects="@(_SdkProjectFlavorMatrixItem)"
       Targets="_SdkGetDebugSymbolsWithTfm"
-      Properties="TargetFramework=%(_SdkTargetsWithRids.Identity);RuntimeIdentifier=%(_SdkTargetsWithRids.Rid)">
-
-      <Output
-          TaskParameter="TargetOutputs"
-          ItemName="_TargetPathsToSymbolsWithRid" />
-    </MSBuild>
-
-    <MSBuild
-      Condition="'$(IncludeBuildOutput)' == 'true' and '%(_SdkTargetsWithRids.Rid)' == ''"
-      Projects="$(MSBuildProjectFullPath)"
-      Targets="_GetDebugSymbolsWithTfm"
-      Properties="TargetFramework=%(_SdkTargetsWithRids.Identity);">
+      Properties="%(_SdkProjectFlavorMatrixItem.SetTargetFramework); %(_SdkProjectFlavorMatrixItem.SetRuntimeIdentifier)">
 
       <Output
         TaskParameter="TargetOutputs"
@@ -123,11 +122,10 @@
     </MSBuild>
 
     <MSBuild
-      Condition="'$(IncludeSource)' == 'true' and '%(_SdkTargetsWithRids.Rid)' == ''"
-      Projects="$(MSBuildProjectFullPath)"
+      Condition="'$(IncludeSource)' == 'true' and '%(_SdkProjectFlavorMatrixItem.Rid)' == ''"
+      Projects="@(_SdkProjectFlavorMatrixItem)"
       Targets="SourceFilesProjectOutputGroup"
-      Properties="TargetFramework=%(_SdkTargetsWithRids.Identity);
-                  BuildProjectReferences=false;">
+      Properties="%(_SdkProjectFlavorMatrixItem.SetTargetFramework); BuildProjectReferences=false">
 
       <Output
           TaskParameter="TargetOutputs"
@@ -135,10 +133,9 @@
     </MSBuild>
 
     <MSBuild
-      Projects="$(MSBuildProjectFullPath)"
+      Projects="@(_SdkProjectFlavorMatrixItem)"
       Targets="_GetFrameworkAssemblyReferences"
-      Properties="TargetFramework=%(_TargetFrameworks.Identity);
-                  BuildProjectReferences=false;">
+      Properties="%(_SdkProjectFlavorMatrixItem.SetTargetFramework); BuildProjectReferences=false">
 
       <Output
           TaskParameter="TargetOutputs"
@@ -150,10 +147,10 @@
     </PropertyGroup>
 
     <MSBuild
-      Projects="$(MSBuildProjectFullPath)" Condition="'$([System.Version]::Parse($(_SdkNETCoreSdkVersion)).CompareTo($([System.Version]::Parse($(_SdkMinVersionWithDependencyTarget)))))' &gt;= '0' "
+      Projects="@(_SdkProjectFlavorMatrixItem)"
+      Condition="'$([System.Version]::Parse($(_SdkNETCoreSdkVersion)).CompareTo($([System.Version]::Parse($(_SdkMinVersionWithDependencyTarget)))))' &gt;= '0' "
       Targets="_GetFrameworksWithSuppressedDependencies"
-      Properties="TargetFramework=%(_TargetFrameworks.Identity);
-                  BuildProjectReferences=false;">
+      Properties="%(_SdkProjectFlavorMatrixItem.SetTargetFramework); BuildProjectReferences=false">
 
       <Output
           TaskParameter="TargetOutputs"
@@ -161,41 +158,83 @@
     </MSBuild>
 
     <ItemGroup>
+      <_BuildOutputInPackageWithRid Include="@(_BuildOutputInPackage->HasMetadata('Rid'))" />
+      <_TargetPathsToSymbolsWithRid Include="@(_TargetPathsToSymbols->HasMetadata('Rid'))" />
+      <_BuildOutputInPackageWithRid Remove="@(_BuildOutputInPackageWithRid)" Condition="'%(Rid)' == ''" />
+      <_TargetPathsToSymbolsWithRid Remove="@(_TargetPathsToSymbolsWithRid)" Condition="'%(Rid)' == ''" />
+      <_BuildOutputInPackage Remove="@(_BuildOutputInPackageWithRid)" />
+      <_TargetPathsToSymbols Remove="@(_TargetPathsToSymbolsWithRid)" />
+      <RidSpecificOutput Include="@(_BuildOutputInPackageWithRid->'%(FinalOutputPath)')" KeepMetadata="$(ExtrasRidSpecificOutputKeepMetadata)" />
+      <RidSpecificOutput Include="@(_TargetPathsToSymbolsWithRid->'%(FinalOutputPath)')" KeepMetadata="$(ExtrasRidSpecificOutputKeepMetadata)" />
+    </ItemGroup>
 
-       <!-- Include the runtimes files -->
-      <None Include="@(_BuildOutputInPackageWithRid)" PackagePath="runtimes/%(_BuildOutputInPackageWithRid.Rid)/lib/%(_BuildOutputInPackageWithRid.TargetFramework)" Pack="true" />
-      <None Include="@(_TargetPathsToSymbolsWithRid)" PackagePath="runtimes/%(_TargetPathsToSymbolsWithRid.Rid)/lib/%(_TargetPathsToSymbolsWithRid.TargetFramework)" Pack="true" />
-    </ItemGroup>  
-    
+  </Target>
+
+
+  <Target Name="_ValidateRidSpecificOutputExists" Condition="'$(ExtrasDisableRidSpecificOutputValidation)' != 'true' and '$(ContinuePackingAfterGeneratingNuspec)' == 'true'">
+
+    <ItemGroup>
+      <_MissingRidSpecificOutput Include="@(RidSpecificOutput)" Condition="!Exists('%(Identity)')"/>
+    </ItemGroup>
+
+    <Warning Text="RuntimeIdentifier-specific output missing before packing, did you forget to use TargetFrameworks instead of TargetFramework?"
+             Condition="'@(_MissingRidSpecificOutput->Count())' != '0' and '$(IsCrossTargetingBuild)' != 'true' and '$(ExtrasSuppressRidSpecificOutputValidationWarnings)' != 'true'" />
+
+    <Warning Text="RuntimeIdentifier-specific output missing before packing."
+             Condition="'@(_MissingRidSpecificOutput->Count())' != '0' and '$(IsCrossTargetingBuild)' == 'true' and '$(ExtrasSuppressRidSpecificOutputValidationWarnings)' != 'true'" />
+
+  </Target>
+
+
+  <Target Name="_WalkEachTargetPerFramework"
+          DependsOnTargets="_WalkEachTargetPerFrameworkCore;$(ExtrasIncludeDefaultProjectBuildOutputInPackTarget);$(_WalkEachTargetPerFrameworkDependsOn);_ValidateRidSpecificOutputExists">
+
+    <PropertyGroup>
+      <ExtrasDisableRidSpecificOutputReleaseOptimization Condition="'$(ExtrasDisableRidSpecificOutputReleaseOptimization)' == ''">false</ExtrasDisableRidSpecificOutputReleaseOptimization>
+    </PropertyGroup>
+
+    <!-- Optional: release references -->
+    <ItemGroup Condition="'$(ExtrasDisableRidSpecificOutputReleaseOptimization)' == 'false'">
+      <RidSpecificOutput Remove="@(RidSpecificOutput)" />
+      <_BuildOutputInPackageWithRid Remove="@(_BuildOutputInPackageWithRid)" />
+      <_TargetPathsToSymbolsWithRid Remove="@(_TargetPathsToSymbolsWithRid)" />
+    </ItemGroup>
+
+  </Target>
+
+
+  <Target Name="_SdkIncludeDefaultProjectBuildOutputInPackImpl" Condition="'$(ExtrasIncludeDefaultProjectBuildOutputInPack)' != 'false'">
+
+    <PropertyGroup>
+      <ExtrasDisableNoneRidSpecificOutputKeepMetadataOptimization Condition="'$(ExtrasDisableNoneRidSpecificOutputKeepMetadataOptimization)' == ''">false</ExtrasDisableNoneRidSpecificOutputKeepMetadataOptimization>
+
+      <!-- Ideally should be empty, but that disables KeepMetadata property -->
+      <ExtrasNoneRidSpecificOutputKeepMetadata Condition="'$(ExtrasNoneRidSpecificOutputKeepMetadata)' == '' and '$(ExtrasDisableNoneRidSpecificOutputKeepMetadataOptimization)' == 'false'">Pack</ExtrasNoneRidSpecificOutputKeepMetadata>
+      <ExtrasNoneRidSpecificOutputKeepMetadata Condition="'$(ExtrasNoneRidSpecificOutputKeepMetadata)' == '' and '$(ExtrasDisableNoneRidSpecificOutputKeepMetadataOptimization)' != 'false'"></ExtrasNoneRidSpecificOutputKeepMetadata>
+    </PropertyGroup>
+
+    <!-- Include the runtimes files -->
+    <ItemGroup>
+      <None Include="@(RidSpecificOutput->'%(Identity)')" PackagePath="runtimes/%(Rid)/lib/%(TargetFramework)" Pack="true" KeepMetadata="$(ExtrasNoneRidSpecificOutputKeepMetadata)" />
+    </ItemGroup>
+
   </Target>
 
 
   <Target Name="_SdkGetBuildOutputFilesWithTfm" DependsOnTargets="_GetBuildOutputFilesWithTfm" Returns="@(BuildOutputInPackage)">
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(RuntimeIdentifier)' != ''">
       <BuildOutputInPackage Update="@(BuildOutputInPackage)" Rid="$(RuntimeIdentifier)" />
     </ItemGroup>
 
   </Target>
 
+
   <Target Name="_SdkGetDebugSymbolsWithTfm" DependsOnTargets="_GetDebugSymbolsWithTfm" Returns="@(_TargetPathsToSymbolsWithTfm)">
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(RuntimeIdentifier)' != ''">
       <_TargetPathsToSymbolsWithTfm Update="@(_TargetPathsToSymbolsWithTfm)" Rid="$(RuntimeIdentifier)" />
     </ItemGroup>
-
-  </Target>
-
-
-  <Target Name="_ExtrasPackageRuntimeFiles" BeforeTargets="_GetPackageFiles" >
-
-    <MSBuild Projects="$(MSBuildProjectFile)"
-             BuildInParallel="$(BuildInParallel)"
-             Properties="TargetFramework=%(_TargetFramework.Identity)"
-             Targets="_SdkGetRidsPerTargetFramework">
-      <Output ItemName="_SdkTargetsWithRids" TaskParameter="TargetOutputs"  />
-    </MSBuild>
-    
 
   </Target>
 

--- a/Tests/ClasslibPackNonRidSpecificCustomTfm/ClasslibPackNonRidSpecificCustomTfm.csproj
+++ b/Tests/ClasslibPackNonRidSpecificCustomTfm/ClasslibPackNonRidSpecificCustomTfm.csproj
@@ -1,0 +1,19 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ExtrasIncludeDefaultProjectBuildOutputInPackTarget>IncludeDefaultProjectBuildOutputInPack</ExtrasIncludeDefaultProjectBuildOutputInPackTarget>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.targets" />
+
+  <Target Name="GenerateNuspec" DependsOnTargets="ClasslibPackNonRidSpecificGenerateNuspec" />
+
+  <Target Name="Test" DependsOnTargets="Pack">
+    <Error Text="GenerateNuspec must be called" Condition="'$(GenerateNuspecCalled)' != 'true'" />
+    <Error Text="IncludeDefaultProjectBuildOutputInPack must be called" Condition="'$(IncludeDefaultProjectBuildOutputInPackCalled)' != 'true'" />
+  </Target>
+
+</Project>

--- a/Tests/ClasslibPackNonRidSpecificCustomTfms/ClasslibPackNonRidSpecificCustomTfms.csproj
+++ b/Tests/ClasslibPackNonRidSpecificCustomTfms/ClasslibPackNonRidSpecificCustomTfms.csproj
@@ -1,0 +1,19 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <ExtrasIncludeDefaultProjectBuildOutputInPackTarget>IncludeDefaultProjectBuildOutputInPack</ExtrasIncludeDefaultProjectBuildOutputInPackTarget>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.targets" />
+
+  <Target Name="GenerateNuspec" DependsOnTargets="ClasslibPackNonRidSpecificGenerateNuspec" />
+
+  <Target Name="Test" DependsOnTargets="Pack">
+    <Error Text="GenerateNuspec must be called" Condition="'$(GenerateNuspecCalled)' != 'true'" />
+    <Error Text="IncludeDefaultProjectBuildOutputInPack must be called" Condition="'$(IncludeDefaultProjectBuildOutputInPackCalled)' != 'true'" />
+  </Target>
+
+</Project>

--- a/Tests/ClasslibPackNonRidSpecificDefaultTfm/ClasslibPackNonRidSpecificDefaultTfm.csproj
+++ b/Tests/ClasslibPackNonRidSpecificDefaultTfm/ClasslibPackNonRidSpecificDefaultTfm.csproj
@@ -1,0 +1,18 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.targets" />
+
+  <Target Name="GenerateNuspec" DependsOnTargets="ClasslibPackNonRidSpecificGenerateNuspec" />
+
+  <Target Name="Test" DependsOnTargets="Pack">
+    <Error Text="GenerateNuspec must be called" Condition="'$(GenerateNuspecCalled)' != 'true'" />
+    <Error Text="IncludeDefaultProjectBuildOutputInPack must not be called" Condition="'$(IncludeDefaultProjectBuildOutputInPackCalled)' != ''" />
+  </Target>
+
+</Project>

--- a/Tests/ClasslibPackNonRidSpecificDefaultTfms/ClasslibPackNonRidSpecificDefaultTfms.csproj
+++ b/Tests/ClasslibPackNonRidSpecificDefaultTfms/ClasslibPackNonRidSpecificDefaultTfms.csproj
@@ -1,0 +1,18 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.targets" />
+
+  <Target Name="GenerateNuspec" DependsOnTargets="ClasslibPackNonRidSpecificGenerateNuspec" />
+
+  <Target Name="Test" DependsOnTargets="Pack">
+    <Error Text="GenerateNuspec must be called" Condition="'$(GenerateNuspecCalled)' != 'true'" />
+    <Error Text="IncludeDefaultProjectBuildOutputInPack must not be called" Condition="'$(IncludeDefaultProjectBuildOutputInPackCalled)' != ''" />
+  </Target>
+
+</Project>

--- a/Tests/ClasslibPackNonRidSpecificSkipTfm/ClasslibPackNonRidSpecificSkipTfm.csproj
+++ b/Tests/ClasslibPackNonRidSpecificSkipTfm/ClasslibPackNonRidSpecificSkipTfm.csproj
@@ -1,0 +1,19 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ExtrasIncludeDefaultProjectBuildOutputInPack>false</ExtrasIncludeDefaultProjectBuildOutputInPack>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.targets" />
+
+  <Target Name="GenerateNuspec" DependsOnTargets="ClasslibPackNonRidSpecificGenerateNuspec" />
+
+  <Target Name="Test" DependsOnTargets="Pack">
+    <Error Text="GenerateNuspec must be called" Condition="'$(GenerateNuspecCalled)' != 'true'" />
+    <Error Text="IncludeDefaultProjectBuildOutputInPack must not be called" Condition="'$(IncludeDefaultProjectBuildOutputInPackCalled)' != ''" />
+  </Target>
+
+</Project>

--- a/Tests/ClasslibPackNonRidSpecificSkipTfms/ClasslibPackNonRidSpecificSkipTfms.csproj
+++ b/Tests/ClasslibPackNonRidSpecificSkipTfms/ClasslibPackNonRidSpecificSkipTfms.csproj
@@ -1,0 +1,19 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <ExtrasIncludeDefaultProjectBuildOutputInPack>false</ExtrasIncludeDefaultProjectBuildOutputInPack>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.targets" />
+
+  <Target Name="GenerateNuspec" DependsOnTargets="ClasslibPackNonRidSpecificGenerateNuspec" />
+
+  <Target Name="Test" DependsOnTargets="Pack">
+    <Error Text="GenerateNuspec must be called" Condition="'$(GenerateNuspecCalled)' != 'true'" />
+    <Error Text="IncludeDefaultProjectBuildOutputInPack must not be called" Condition="'$(IncludeDefaultProjectBuildOutputInPackCalled)' != ''" />
+  </Target>
+
+</Project>

--- a/Tests/ClasslibPackRidSpecificCustomTfm/ClasslibPackRidSpecificCustomTfm.csproj
+++ b/Tests/ClasslibPackRidSpecificCustomTfm/ClasslibPackRidSpecificCustomTfm.csproj
@@ -1,0 +1,52 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RuntimeIdentifiers>win;unix</RuntimeIdentifiers>
+    <ExtrasBuildEachRuntimeIdentifier>true</ExtrasBuildEachRuntimeIdentifier>
+    <ExtrasIncludeDefaultProjectBuildOutputInPackTarget>IncludeDefaultProjectBuildOutputInPack</ExtrasIncludeDefaultProjectBuildOutputInPackTarget>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.targets" />
+
+  <Target Name="GenerateNuspec" DependsOnTargets="$(GenerateNuspecDependsOn);_CalculateInputsOutputsForPack;_GetProjectReferenceVersions;_InitializeNuspecRepositoryInformationProperties" Condition="$(IsPackable) == 'true'"
+          Inputs="@(NuGetPackInput)" Outputs="@(NuGetPackOutput)">
+
+    <PropertyGroup>
+      <GenerateNuspecCalled>true</GenerateNuspecCalled>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <TestNuGetPackInputOutputAssembly Include="@(NuGetPackInput->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.dll'))" />
+      <TestNuGetPackInputOutputSymbols Include="@(NuGetPackInput->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.pdb'))" />
+      <TestPackageFilesOutputAssembly Include="@(_PackageFiles->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.dll'))" />
+      <TestPackageFilesOutputSymbols Include="@(_PackageFiles->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.pdb'))" />
+    </ItemGroup>
+
+    <Error Text="NuGetPackInput must contain the output DLLs" Condition="'@(TestNuGetPackInputOutputAssembly->Count())' != '2'" />
+    <Error Text="NuGetPackInput must contain output PDBs" Condition="'@(TestNuGetPackInputOutputSymbols->Count())' != '2'" />
+    <Error Text="NuGetPackInput must contain output DLL for win RID" Condition="'@(TestNuGetPackInputOutputAssembly->WithMetadataValue('PackagePath', 'tools/netstandard2.0/win')->Count())' != '1'" />
+    <Error Text="NuGetPackInput must contain output PDB for win RID" Condition="'@(TestNuGetPackInputOutputSymbols->WithMetadataValue('PackagePath', 'tools/netstandard2.0/win')->Count())' != '1'" />
+    <Error Text="NuGetPackInput must contain output DLL for unix RID" Condition="'@(TestNuGetPackInputOutputAssembly->WithMetadataValue('PackagePath', 'tools/netstandard2.0/unix')->Count())' != '1'" />
+    <Error Text="NuGetPackInput must contain output PDB for unix RID" Condition="'@(TestNuGetPackInputOutputSymbols->WithMetadataValue('PackagePath', 'tools/netstandard2.0/unix')->Count())' != '1'" />
+    <Error Text="BuildOutputInPackage must be empty" Condition="'@(_BuildOutputInPackage->Count())' != '0'" />
+    <Error Text="TargetPathsToSymbols must be empty" Condition="'@(_TargetPathsToSymbols->Count())' != '0'" />
+    <Error Text="_PackageFiles must contain exactly 2×2 items" Condition="'@(_PackageFiles->Count())' != '4'" />
+    <Error Text="_PackageFiles must contain the output DLLs" Condition="'@(TestPackageFilesOutputAssembly->Count())' != '2'" />
+    <Error Text="_PackageFiles must contain output PDBs" Condition="'@(TestPackageFilesOutputSymbols->Count())' != '2'" />
+    <Error Text="_PackageFiles must contain output DLL for win RID" Condition="'@(TestPackageFilesOutputAssembly->WithMetadataValue('PackagePath', 'tools/netstandard2.0/win')->Count())' != '1'" />
+    <Error Text="_PackageFiles must contain output PDB for win RID" Condition="'@(TestPackageFilesOutputSymbols->WithMetadataValue('PackagePath', 'tools/netstandard2.0/win')->Count())' != '1'" />
+    <Error Text="_PackageFiles must contain output DLL for unix RID" Condition="'@(TestPackageFilesOutputAssembly->WithMetadataValue('PackagePath', 'tools/netstandard2.0/unix')->Count())' != '1'" />
+    <Error Text="_PackageFiles must contain output PDB for unix RID" Condition="'@(TestPackageFilesOutputSymbols->WithMetadataValue('PackagePath', 'tools/netstandard2.0/unix')->Count())' != '1'" />
+    <Error Text="Missing output warnings generated" Condition="'@(_MissingRidSpecificOutput->Count())' != '4'" />
+
+  </Target>
+
+  <Target Name="Test" DependsOnTargets="Pack">
+    <Error Text="GenerateNuspec must be called" Condition="'$(GenerateNuspecCalled)' != 'true'" />
+    <Error Text="IncludeDefaultProjectBuildOutputInPack must be called" Condition="'$(IncludeDefaultProjectBuildOutputInPackCalled)' != 'true'" />
+  </Target>
+
+</Project>

--- a/Tests/ClasslibPackRidSpecificCustomTfms/ClasslibPackRidSpecificCustomTfms.csproj
+++ b/Tests/ClasslibPackRidSpecificCustomTfms/ClasslibPackRidSpecificCustomTfms.csproj
@@ -1,0 +1,52 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <RuntimeIdentifiers>win;unix</RuntimeIdentifiers>
+    <ExtrasBuildEachRuntimeIdentifier>true</ExtrasBuildEachRuntimeIdentifier>
+    <ExtrasIncludeDefaultProjectBuildOutputInPackTarget>IncludeDefaultProjectBuildOutputInPack</ExtrasIncludeDefaultProjectBuildOutputInPackTarget>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.targets" />
+
+  <Target Name="GenerateNuspec" DependsOnTargets="$(GenerateNuspecDependsOn);_CalculateInputsOutputsForPack;_GetProjectReferenceVersions;_InitializeNuspecRepositoryInformationProperties" Condition="$(IsPackable) == 'true'"
+          Inputs="@(NuGetPackInput)" Outputs="@(NuGetPackOutput)">
+
+    <PropertyGroup>
+      <GenerateNuspecCalled>true</GenerateNuspecCalled>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <TestNuGetPackInputOutputAssembly Include="@(NuGetPackInput->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.dll'))" />
+      <TestNuGetPackInputOutputSymbols Include="@(NuGetPackInput->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.pdb'))" />
+      <TestPackageFilesOutputAssembly Include="@(_PackageFiles->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.dll'))" />
+      <TestPackageFilesOutputSymbols Include="@(_PackageFiles->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.pdb'))" />
+    </ItemGroup>
+
+    <Error Text="NuGetPackInput must contain the output DLLs" Condition="'@(TestNuGetPackInputOutputAssembly->Count())' != '2'" />
+    <Error Text="NuGetPackInput must contain output PDBs" Condition="'@(TestNuGetPackInputOutputSymbols->Count())' != '2'" />
+    <Error Text="NuGetPackInput must contain output DLL for win RID" Condition="'@(TestNuGetPackInputOutputAssembly->WithMetadataValue('PackagePath', 'tools/netstandard2.0/win')->Count())' != '1'" />
+    <Error Text="NuGetPackInput must contain output PDB for win RID" Condition="'@(TestNuGetPackInputOutputSymbols->WithMetadataValue('PackagePath', 'tools/netstandard2.0/win')->Count())' != '1'" />
+    <Error Text="NuGetPackInput must contain output DLL for unix RID" Condition="'@(TestNuGetPackInputOutputAssembly->WithMetadataValue('PackagePath', 'tools/netstandard2.0/unix')->Count())' != '1'" />
+    <Error Text="NuGetPackInput must contain output PDB for unix RID" Condition="'@(TestNuGetPackInputOutputSymbols->WithMetadataValue('PackagePath', 'tools/netstandard2.0/unix')->Count())' != '1'" />
+    <Error Text="BuildOutputInPackage must be empty" Condition="'@(_BuildOutputInPackage->Count())' != '0'" />
+    <Error Text="TargetPathsToSymbols must be empty" Condition="'@(_TargetPathsToSymbols->Count())' != '0'" />
+    <Error Text="_PackageFiles must contain exactly 2×2 items" Condition="'@(_PackageFiles->Count())' != '4'" />
+    <Error Text="_PackageFiles must contain the output DLLs" Condition="'@(TestPackageFilesOutputAssembly->Count())' != '2'" />
+    <Error Text="_PackageFiles must contain output PDBs" Condition="'@(TestPackageFilesOutputSymbols->Count())' != '2'" />
+    <Error Text="_PackageFiles must contain output DLL for win RID" Condition="'@(TestPackageFilesOutputAssembly->WithMetadataValue('PackagePath', 'tools/netstandard2.0/win')->Count())' != '1'" />
+    <Error Text="_PackageFiles must contain output PDB for win RID" Condition="'@(TestPackageFilesOutputSymbols->WithMetadataValue('PackagePath', 'tools/netstandard2.0/win')->Count())' != '1'" />
+    <Error Text="_PackageFiles must contain output DLL for unix RID" Condition="'@(TestPackageFilesOutputAssembly->WithMetadataValue('PackagePath', 'tools/netstandard2.0/unix')->Count())' != '1'" />
+    <Error Text="_PackageFiles must contain output PDB for unix RID" Condition="'@(TestPackageFilesOutputSymbols->WithMetadataValue('PackagePath', 'tools/netstandard2.0/unix')->Count())' != '1'" />
+    <Error Text="No missing output warning generated" Condition="'@(_MissingRidSpecificOutput->Count())' != '0'" />
+
+  </Target>
+
+  <Target Name="Test" DependsOnTargets="Pack">
+    <Error Text="GenerateNuspec must be called" Condition="'$(GenerateNuspecCalled)' != 'true'" />
+    <Error Text="IncludeDefaultProjectBuildOutputInPack must be called" Condition="'$(IncludeDefaultProjectBuildOutputInPackCalled)' != 'true'" />
+  </Target>
+
+</Project>

--- a/Tests/ClasslibPackRidSpecificDefaultTfm/ClasslibPackRidSpecificDefaultTfm.csproj
+++ b/Tests/ClasslibPackRidSpecificDefaultTfm/ClasslibPackRidSpecificDefaultTfm.csproj
@@ -1,0 +1,51 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RuntimeIdentifiers>win;unix</RuntimeIdentifiers>
+    <ExtrasBuildEachRuntimeIdentifier>true</ExtrasBuildEachRuntimeIdentifier>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.targets" />
+
+  <Target Name="GenerateNuspec" DependsOnTargets="$(GenerateNuspecDependsOn);_CalculateInputsOutputsForPack;_GetProjectReferenceVersions;_InitializeNuspecRepositoryInformationProperties" Condition="$(IsPackable) == 'true'"
+          Inputs="@(NuGetPackInput)" Outputs="@(NuGetPackOutput)">
+
+    <PropertyGroup>
+      <GenerateNuspecCalled>true</GenerateNuspecCalled>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <TestNuGetPackInputOutputAssembly Include="@(NuGetPackInput->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.dll'))" />
+      <TestNuGetPackInputOutputSymbols Include="@(NuGetPackInput->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.pdb'))" />
+      <TestPackageFilesOutputAssembly Include="@(_PackageFiles->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.dll'))" />
+      <TestPackageFilesOutputSymbols Include="@(_PackageFiles->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.pdb'))" />
+    </ItemGroup>
+
+    <Error Text="NuGetPackInput must contain the output DLLs" Condition="'@(TestNuGetPackInputOutputAssembly->Count())' != '2'" />
+    <Error Text="NuGetPackInput must contain output PDBs" Condition="'@(TestNuGetPackInputOutputSymbols->Count())' != '2'" />
+    <Error Text="NuGetPackInput must contain output DLL for win RID" Condition="'@(TestNuGetPackInputOutputAssembly->WithMetadataValue('PackagePath', 'runtimes/win/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="NuGetPackInput must contain output PDB for win RID" Condition="'@(TestNuGetPackInputOutputSymbols->WithMetadataValue('PackagePath', 'runtimes/win/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="NuGetPackInput must contain output DLL for unix RID" Condition="'@(TestNuGetPackInputOutputAssembly->WithMetadataValue('PackagePath', 'runtimes/unix/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="NuGetPackInput must contain output PDB for unix RID" Condition="'@(TestNuGetPackInputOutputSymbols->WithMetadataValue('PackagePath', 'runtimes/unix/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="BuildOutputInPackage must be empty" Condition="'@(_BuildOutputInPackage->Count())' != '0'" />
+    <Error Text="TargetPathsToSymbols must be empty" Condition="'@(_TargetPathsToSymbols->Count())' != '0'" />
+    <Error Text="_PackageFiles must contain exactly 2×2 items" Condition="'@(_PackageFiles->Count())' != '4'" />
+    <Error Text="_PackageFiles must contain the output DLLs" Condition="'@(TestPackageFilesOutputAssembly->Count())' != '2'" />
+    <Error Text="_PackageFiles must contain output PDBs" Condition="'@(TestPackageFilesOutputSymbols->Count())' != '2'" />
+    <Error Text="_PackageFiles must contain output DLL for win RID" Condition="'@(TestPackageFilesOutputAssembly->WithMetadataValue('PackagePath', 'runtimes/win/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="_PackageFiles must contain output PDB for win RID" Condition="'@(TestPackageFilesOutputSymbols->WithMetadataValue('PackagePath', 'runtimes/win/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="_PackageFiles must contain output DLL for unix RID" Condition="'@(TestPackageFilesOutputAssembly->WithMetadataValue('PackagePath', 'runtimes/unix/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="_PackageFiles must contain output PDB for unix RID" Condition="'@(TestPackageFilesOutputSymbols->WithMetadataValue('PackagePath', 'runtimes/unix/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="Missing output warnings generated" Condition="'@(_MissingRidSpecificOutput->Count())' != '4'" />
+
+  </Target>
+
+  <Target Name="Test" DependsOnTargets="Pack">
+    <Error Text="GenerateNuspec must be called" Condition="'$(GenerateNuspecCalled)' != 'true'" />
+    <Error Text="IncludeDefaultProjectBuildOutputInPack must not be called" Condition="'$(IncludeDefaultProjectBuildOutputInPackCalled)' != ''" />
+  </Target>
+
+</Project>

--- a/Tests/ClasslibPackRidSpecificDefaultTfms/ClasslibPackRidSpecificDefaultTfms.csproj
+++ b/Tests/ClasslibPackRidSpecificDefaultTfms/ClasslibPackRidSpecificDefaultTfms.csproj
@@ -1,0 +1,51 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <RuntimeIdentifiers>win;unix</RuntimeIdentifiers>
+    <ExtrasBuildEachRuntimeIdentifier>true</ExtrasBuildEachRuntimeIdentifier>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.targets" />
+
+  <Target Name="GenerateNuspec" DependsOnTargets="$(GenerateNuspecDependsOn);_CalculateInputsOutputsForPack;_GetProjectReferenceVersions;_InitializeNuspecRepositoryInformationProperties" Condition="$(IsPackable) == 'true'"
+          Inputs="@(NuGetPackInput)" Outputs="@(NuGetPackOutput)">
+
+    <PropertyGroup>
+      <GenerateNuspecCalled>true</GenerateNuspecCalled>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <TestNuGetPackInputOutputAssembly Include="@(NuGetPackInput->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.dll'))" />
+      <TestNuGetPackInputOutputSymbols Include="@(NuGetPackInput->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.pdb'))" />
+      <TestPackageFilesOutputAssembly Include="@(_PackageFiles->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.dll'))" />
+      <TestPackageFilesOutputSymbols Include="@(_PackageFiles->WithMetadataValue('BuildAction', 'None')->WithMetadataValue('Pack', 'true')->HasMetadata('PackagePath')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.pdb'))" />
+    </ItemGroup>
+
+    <Error Text="NuGetPackInput must contain the output DLLs" Condition="'@(TestNuGetPackInputOutputAssembly->Count())' != '2'" />
+    <Error Text="NuGetPackInput must contain output PDBs" Condition="'@(TestNuGetPackInputOutputSymbols->Count())' != '2'" />
+    <Error Text="NuGetPackInput must contain output DLL for win RID" Condition="'@(TestNuGetPackInputOutputAssembly->WithMetadataValue('PackagePath', 'runtimes/win/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="NuGetPackInput must contain output PDB for win RID" Condition="'@(TestNuGetPackInputOutputSymbols->WithMetadataValue('PackagePath', 'runtimes/win/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="NuGetPackInput must contain output DLL for unix RID" Condition="'@(TestNuGetPackInputOutputAssembly->WithMetadataValue('PackagePath', 'runtimes/unix/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="NuGetPackInput must contain output PDB for unix RID" Condition="'@(TestNuGetPackInputOutputSymbols->WithMetadataValue('PackagePath', 'runtimes/unix/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="BuildOutputInPackage must be empty" Condition="'@(_BuildOutputInPackage->Count())' != '0'" />
+    <Error Text="TargetPathsToSymbols must be empty" Condition="'@(_TargetPathsToSymbols->Count())' != '0'" />
+    <Error Text="_PackageFiles must contain exactly 2×2 items" Condition="'@(_PackageFiles->Count())' != '4'" />
+    <Error Text="_PackageFiles must contain the output DLLs" Condition="'@(TestPackageFilesOutputAssembly->Count())' != '2'" />
+    <Error Text="_PackageFiles must contain output PDBs" Condition="'@(TestPackageFilesOutputSymbols->Count())' != '2'" />
+    <Error Text="_PackageFiles must contain output DLL for win RID" Condition="'@(TestPackageFilesOutputAssembly->WithMetadataValue('PackagePath', 'runtimes/win/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="_PackageFiles must contain output PDB for win RID" Condition="'@(TestPackageFilesOutputSymbols->WithMetadataValue('PackagePath', 'runtimes/win/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="_PackageFiles must contain output DLL for unix RID" Condition="'@(TestPackageFilesOutputAssembly->WithMetadataValue('PackagePath', 'runtimes/unix/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="_PackageFiles must contain output PDB for unix RID" Condition="'@(TestPackageFilesOutputSymbols->WithMetadataValue('PackagePath', 'runtimes/unix/lib/netstandard2.0')->Count())' != '1'" />
+    <Error Text="No missing output warning generated" Condition="'@(_MissingRidSpecificOutput->Count())' != '0'" />
+
+  </Target>
+
+  <Target Name="Test" DependsOnTargets="Pack">
+    <Error Text="GenerateNuspec must be called" Condition="'$(GenerateNuspecCalled)' != 'true'" />
+    <Error Text="IncludeDefaultProjectBuildOutputInPack must not be called" Condition="'$(IncludeDefaultProjectBuildOutputInPackCalled)' != ''" />
+  </Target>
+
+</Project>

--- a/Tests/ClasslibPackRidSpecificSkipTfm/ClasslibPackRidSpecificSkipTfm.csproj
+++ b/Tests/ClasslibPackRidSpecificSkipTfm/ClasslibPackRidSpecificSkipTfm.csproj
@@ -1,0 +1,40 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RuntimeIdentifiers>win;unix</RuntimeIdentifiers>
+    <ExtrasBuildEachRuntimeIdentifier>true</ExtrasBuildEachRuntimeIdentifier>
+    <ExtrasIncludeDefaultProjectBuildOutputInPack>false</ExtrasIncludeDefaultProjectBuildOutputInPack>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.targets" />
+
+  <Target Name="GenerateNuspec" DependsOnTargets="$(GenerateNuspecDependsOn);_CalculateInputsOutputsForPack;_GetProjectReferenceVersions;_InitializeNuspecRepositoryInformationProperties" Condition="$(IsPackable) == 'true'"
+          Inputs="@(NuGetPackInput)" Outputs="@(NuGetPackOutput)">
+
+    <PropertyGroup>
+      <GenerateNuspecCalled>true</GenerateNuspecCalled>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <TestNuGetPackInputOutputAssembly Include="@(NuGetPackInput->WithMetadataValue('Extension', '.dll'))" />
+      <TestNuGetPackInputOutputSymbols Include="@(NuGetPackInput->WithMetadataValue('Extension', '.pdb'))" />
+    </ItemGroup>
+
+    <Error Text="NuGetPackInput must not contain the output DLL" Condition="'@(TestNuGetPackInputOutputAssembly->Count())' != '0'" />
+    <Error Text="NuGetPackInput must not contain output PDB" Condition="'@(TestNuGetPackInputOutputSymbols->Count())' != '0'" />
+    <Error Text="BuildOutputInPackage must be empty" Condition="'@(_BuildOutputInPackage->Count())' != '0'" />
+    <Error Text="TargetPathsToSymbols must be empty" Condition="'@(_TargetPathsToSymbols->Count())' != '0'" />
+    <Error Text="_PackageFiles must be empty" Condition="'@(_PackageFiles->Count())' != '0'" />
+    <Error Text="Missing output warnings generated" Condition="'@(_MissingRidSpecificOutput->Count())' != '4'" />
+
+  </Target>
+
+  <Target Name="Test" DependsOnTargets="Pack">
+    <Error Text="GenerateNuspec must be called" Condition="'$(GenerateNuspecCalled)' != 'true'" />
+    <Error Text="IncludeDefaultProjectBuildOutputInPack must not be called" Condition="'$(IncludeDefaultProjectBuildOutputInPackCalled)' != ''" />
+  </Target>
+
+</Project>

--- a/Tests/ClasslibPackRidSpecificSkipTfms/ClasslibPackRidSpecificSkipTfms.csproj
+++ b/Tests/ClasslibPackRidSpecificSkipTfms/ClasslibPackRidSpecificSkipTfms.csproj
@@ -1,0 +1,40 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <RuntimeIdentifiers>win;unix</RuntimeIdentifiers>
+    <ExtrasBuildEachRuntimeIdentifier>true</ExtrasBuildEachRuntimeIdentifier>
+    <ExtrasIncludeDefaultProjectBuildOutputInPack>false</ExtrasIncludeDefaultProjectBuildOutputInPack>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Source\MSBuild.Sdk.Extras\Sdk\Sdk.targets" />
+
+  <Target Name="GenerateNuspec" DependsOnTargets="$(GenerateNuspecDependsOn);_CalculateInputsOutputsForPack;_GetProjectReferenceVersions;_InitializeNuspecRepositoryInformationProperties" Condition="$(IsPackable) == 'true'"
+          Inputs="@(NuGetPackInput)" Outputs="@(NuGetPackOutput)">
+
+    <PropertyGroup>
+      <GenerateNuspecCalled>true</GenerateNuspecCalled>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <TestNuGetPackInputOutputAssembly Include="@(NuGetPackInput->WithMetadataValue('Extension', '.dll'))" />
+      <TestNuGetPackInputOutputSymbols Include="@(NuGetPackInput->WithMetadataValue('Extension', '.pdb'))" />
+    </ItemGroup>
+
+    <Error Text="NuGetPackInput must not contain the output DLL" Condition="'@(TestNuGetPackInputOutputAssembly->Count())' != '0'" />
+    <Error Text="NuGetPackInput must not contain output PDB" Condition="'@(TestNuGetPackInputOutputSymbols->Count())' != '0'" />
+    <Error Text="BuildOutputInPackage must be empty" Condition="'@(_BuildOutputInPackage->Count())' != '0'" />
+    <Error Text="TargetPathsToSymbols must be empty" Condition="'@(_TargetPathsToSymbols->Count())' != '0'" />
+    <Error Text="_PackageFiles must be empty" Condition="'@(_PackageFiles->Count())' != '0'" />
+    <Error Text="No missing output warning generated" Condition="'@(_MissingRidSpecificOutput->Count())' != '0'" />
+
+  </Target>
+
+  <Target Name="Test" DependsOnTargets="Pack">
+    <Error Text="GenerateNuspec must be called" Condition="'$(GenerateNuspecCalled)' != 'true'" />
+    <Error Text="IncludeDefaultProjectBuildOutputInPack must not be called" Condition="'$(IncludeDefaultProjectBuildOutputInPackCalled)' != ''" />
+  </Target>
+
+</Project>

--- a/Tests/ClasslibPackTests.msbuildproj
+++ b/Tests/ClasslibPackTests.msbuildproj
@@ -1,0 +1,60 @@
+<Project DefaultTargets="Build">
+
+  <PropertyGroup>
+    <ContinueOnError Condition="'$(ContinueOnError)' == ''">ErrorAndContinue</ContinueOnError>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <ProjectReference>
+      <SetConfiguration Condition="'$(Configuration)' != ''">Configuration=$(Configuration)</SetConfiguration>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <ProjectCapability Include="DependenciesTree" />
+
+    <ProjectReference Include="ClasslibPack*/*.csproj" />
+  </ItemGroup>
+
+  <Target Name="Test">
+    <MSBuild
+        Projects="@(ProjectReference)"
+        Targets="Test"
+        BuildInParallel="$(BuildInParallel)"
+        Properties="%(ProjectReference.SetConfiguration)"
+        Condition="'@(ProjectReference)' != ''"
+        ContinueOnError="$(ContinueOnError)" />
+  </Target>
+
+  <Target Name="Clean">
+    <MSBuild
+        Projects="@(ProjectReference)"
+        Targets="Clean"
+        BuildInParallel="$(BuildInParallel)"
+        Properties="%(ProjectReference.SetConfiguration)"
+        Condition="'@(ProjectReference)' != ''"
+        ContinueOnError="$(ContinueOnError)" />
+  </Target>
+
+  <Target Name="Restore">
+    <MSBuild
+        Projects="@(ProjectReference)"
+        Targets="Restore"
+        BuildInParallel="$(BuildInParallel)"
+        Properties="%(ProjectReference.SetConfiguration)"
+        Condition="'@(ProjectReference)' != ''"
+        ContinueOnError="$(ContinueOnError)" />
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="Test" />
+
+  <!-- For CPS/VS support. -->
+  <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
+  <Target Name="CompileDesignTime" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets" 
+          Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')" />
+  <Target Name="GetTargetPath" /> 
+  <Target Name="GetTargetPathWithTargetPlatformMoniker" />
+  <Target Name="ResolveProjectReferencesDesignTime" Returns="@(ProjectReference)" />
+
+</Project>

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+
+    <PropertyGroup>
+        <ExtrasSuppressRidSpecificOutputValidationWarnings>true</ExtrasSuppressRidSpecificOutputValidationWarnings>
+    </PropertyGroup>
+
+</Project>

--- a/Tests/Directory.Build.targets
+++ b/Tests/Directory.Build.targets
@@ -1,7 +1,46 @@
 <Project>
 
-	<Target Name="_EnsureTempSource" BeforeTargets="Restore">
-		<MakeDir Directories="$(TEMP)\packages" Condition="!Exists('$(TEMP)\packages')" />
-	</Target>
+  <Target Name="_EnsureTempSource" BeforeTargets="Restore">
+    <MakeDir Directories="$(TEMP)\packages" Condition="!Exists('$(TEMP)\packages')" />
+  </Target>
+
+  <Target Name="IncludeDefaultProjectBuildOutputInPack">
+
+    <PropertyGroup>
+      <IncludeDefaultProjectBuildOutputInPackCalled>true</IncludeDefaultProjectBuildOutputInPackCalled>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <None Include="@(RidSpecificOutput->'%(Identity)')" PackagePath="tools/%(TargetFramework)/%(Rid)" Pack="true" KeepMetadata="FakeProperty" />
+    </ItemGroup>
+
+  </Target>
+
+  <Target Name="ClasslibPackNonRidSpecificGenerateNuspec" DependsOnTargets="$(GenerateNuspecDependsOn);_CalculateInputsOutputsForPack;_GetProjectReferenceVersions;_InitializeNuspecRepositoryInformationProperties" Condition="$(IsPackable) == 'true'"
+          Inputs="@(NuGetPackInput)" Outputs="@(NuGetPackOutput)">
+
+    <PropertyGroup>
+      <GenerateNuspecCalled>true</GenerateNuspecCalled>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <TestNuGetPackInputOutputAssembly Include="@(NuGetPackInput->WithMetadataValue('TargetFramework', 'netstandard2.0')->WithMetadataValue('MSBuildSourceProjectFile', '$(MSBuildProjectFullPath)')->WithMetadataValue('MSBuildSourceTargetName', '_SdkGetBuildOutputFilesWithTfm')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.dll')->WithMetadataValue('IsKeyOutput', 'true'))" />
+      <TestNuGetPackInputOutputSymbols Include="@(NuGetPackInput->WithMetadataValue('TargetFramework', 'netstandard2.0')->WithMetadataValue('MSBuildSourceProjectFile', '$(MSBuildProjectFullPath)')->WithMetadataValue('MSBuildSourceTargetName', '_SdkGetDebugSymbolsWithTfm')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.pdb'))" />
+      <TestOutputAssembly Include="@(_BuildOutputInPackage->WithMetadataValue('TargetFramework', 'netstandard2.0')->WithMetadataValue('MSBuildSourceProjectFile', '$(MSBuildProjectFullPath)')->WithMetadataValue('MSBuildSourceTargetName', '_SdkGetBuildOutputFilesWithTfm')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.dll')->WithMetadataValue('IsKeyOutput', 'true'))" />
+      <TestOutputSymbols Include="@(_TargetPathsToSymbols->WithMetadataValue('TargetFramework', 'netstandard2.0')->WithMetadataValue('MSBuildSourceProjectFile', '$(MSBuildProjectFullPath)')->WithMetadataValue('MSBuildSourceTargetName', '_SdkGetDebugSymbolsWithTfm')->WithMetadataValue('Filename', '$(MSBuildProjectName)')->WithMetadataValue('Extension', '.pdb'))" />
+    </ItemGroup>
+
+    <Error Text="NuGetPackInput must contain the output DLL" Condition="'@(TestNuGetPackInputOutputAssembly->Count())' != '1'" />
+    <Error Text="NuGetPackInput must contain output PDB" Condition="'@(TestNuGetPackInputOutputSymbols->Count())' != '1'" />
+    <Error Text="NuGetPackInput output DLL must be Rid-agnostic" Condition="'@(TestNuGetPackInputOutputAssembly->HasMetadata('Rid')->Count())' != '0'" />
+    <Error Text="NuGetPackInput output PDB must be Rid-agnostic" Condition="'@(TestNuGetPackInputOutputSymbols->HasMetadata('Rid')->Count())' != '0'" />
+    <Error Text="BuildOutputInPackage must contain the output DLL" Condition="'@(TestOutputAssembly->Count())' != '1'" />
+    <Error Text="TargetPathsToSymbols must contain output PDB" Condition="'@(TestOutputSymbols->Count())' != '1'" />
+    <Error Text="BuildOutputInPackage must be Rid-agnostic" Condition="'@(TestOutputAssembly->HasMetadata('Rid')->Count())' != '0'" />
+    <Error Text="TargetPathsToSymbols must be Rid-agnostic" Condition="'@(TestOutputSymbols->HasMetadata('Rid')->Count())' != '0'" />
+    <Error Text="_PackageFiles must be empty" Condition="'@(_PackageFiles->Count())' != '0'" />
+    <Error Text="No missing output warning generated" Condition="'@(_MissingRidSpecificOutput->Count())' != '0'" />
+
+  </Target>
 
 </Project>


### PR DESCRIPTION
* `ExtrasIncludeDefaultProjectBuildOutputInPackTarget` allows overriding the target which packs the RID-specific build output (assemblies and symbols), fixes #217.
* Update to latest `Microsoft.Common.CrossTargeting.targets` upstream source code.
* `_SdkPrepareProjectFlavorMatrix` is now responsible for computing project flavors matrix: `TargetFramework` × `RuntimeIdentifier`.
* Reimplement `_ComputeTargetFrameworkItems` and `_WalkEachTargetPerFramework` on top of `_SdkPrepareProjectFlavorMatrix`
* Mimic `ProjectReference` item spec to simplify `_WalkEachTargetPerFramework` (by removing duplication)
* Use `MSBuildProjectFullPath` consistently, avoid `MSBuildProjectFile` or mixing those two.
* Drop no-op `_ExtrasPackageRuntimeFiles`.
* Pay attention to unnecessary metadata, use `KeepMetadata` where applicable (opt-out possible and verified).

[`PackagePath` override sample](https://github.com/SharpGenTools/SharpGenTools/pull/161/commits/2579a5d1c79ab0c6157dfda4edc3c90958c5393b)