### PR TITLE
Fully qualify metadata to avoid conflict between None and RidSpecificOutput

### DIFF
--- a/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/RIDs.targets
@@ -215,7 +215,7 @@
 
     <!-- Include the runtimes files -->
     <ItemGroup>
-      <None Include="@(RidSpecificOutput->'%(Identity)')" PackagePath="runtimes/%(Rid)/lib/%(TargetFramework)" Pack="true" KeepMetadata="$(ExtrasNoneRidSpecificOutputKeepMetadata)" />
+      <None Include="@(RidSpecificOutput->'%(Identity)')" PackagePath="runtimes/%(RidSpecificOutput.Rid)/lib/%(RidSpecificOutput.TargetFramework)" Pack="true" KeepMetadata="$(ExtrasNoneRidSpecificOutputKeepMetadata)" />
     </ItemGroup>
 
   </Target>


### PR DESCRIPTION
Fix for #226 