### PR TITLE
Don't include WindowsDesktop.props for 5.0 SDK

### DIFF
--- a/Source/MSBuild.Sdk.Extras/Build/ExtrasShim.targets
+++ b/Source/MSBuild.Sdk.Extras/Build/ExtrasShim.targets
@@ -26,7 +26,7 @@
     <UseWindowsForms Condition="'$(UseWindowsForms)' == '' and '$(ExtrasEnableWinFormsProjectSetup)' == 'true' ">true</UseWindowsForms>
 
     <!-- Until there's a discreet property for this, default based on Wpf/WinForms -->
-    <ExtrasUseWindowsDesktopApp Condition="'$(_ExtrasHasDesktopSdk)' == 'true' and ('$(UseWpf)' == 'true' or '$(UseWindowsForms)' == 'true')">true</ExtrasUseWindowsDesktopApp>
+    <ExtrasUseWindowsDesktopApp Condition="'$(ExtrasUseWindowsDesktopApp)' == '' and '$(_ExtrasHasDesktopSdk)' == 'true' and ('$(UseWpf)' == 'true' or '$(UseWindowsForms)' == 'true')">true</ExtrasUseWindowsDesktopApp>
     <ExtrasUseWindowsDesktopApp Condition="'$(ExtrasUseWindowsDesktopApp)' == '' ">false</ExtrasUseWindowsDesktopApp>
   </PropertyGroup>
 

--- a/Source/MSBuild.Sdk.Extras/Sdk/Sdk.props
+++ b/Source/MSBuild.Sdk.Extras/Sdk/Sdk.props
@@ -22,7 +22,7 @@
   
   <Import Condition=" '$(_ExtrasHasDesktopSdk)' != 'true' " Project="$(MSBuildThisFileDirectory)..\Build\Workarounds.props" />
 
-  <Import Condition="'$(_ExtrasHasDesktopSdk)' == 'true' " Project="$(MicrosoftWindowsDesktopSdkPath)\Microsoft.NET.Sdk.WindowsDesktop.props "/>
+  <Import Condition="'$(_ExtrasHasDesktopSdk)' == 'true' and !$(NETCoreSdkVersion.StartsWith('5'))" Project="$(MicrosoftWindowsDesktopSdkPath)\Microsoft.NET.Sdk.WindowsDesktop.props "/>
 
   <!-- TODO: Revisit once there's a way to control this directly -->
   <ItemGroup Condition="'$(ExtrasUseWindowsDesktopApp)' != 'true'">

--- a/Source/MSBuild.Sdk.Extras/Sdk/Sdk.props
+++ b/Source/MSBuild.Sdk.Extras/Sdk/Sdk.props
@@ -17,15 +17,18 @@
     <MicrosoftWindowsDesktopSdkPath Condition="Exists('$(_ExtrasSdkBaseDirectory)Microsoft.NET.Sdk.WindowsDesktop\Sdk\Sdk.props')">$(_ExtrasSdkBaseDirectory)Microsoft.NET.Sdk.WindowsDesktop\targets</MicrosoftWindowsDesktopSdkPath>
     <_ExtrasHasDesktopSdk Condition="'$(MicrosoftWindowsDesktopSdkPath)' != ''">true</_ExtrasHasDesktopSdk>
     <_ExtrasHasDesktopSdk Condition="'$(_ExtrasHasDesktopSdk)' == ''">false</_ExtrasHasDesktopSdk>
+    <!-- 5.0 SDK includes WindowsDesktop.props automatically, so we should not do it -->
+    <_ExtrasHasNet5OrGreaterSDK Condition="'$(NETCoreSdkVersion)' != '' and '$(NETCoreSdkVersion[0])' &gt;= '5'">true</_ExtrasHasNet5OrGreaterSDK>
+    <ExtrasUseWindowsDesktopApp Condition="'$(_ExtrasHasNet5OrGreaterSDK)' == 'true'">false</ExtrasUseWindowsDesktopApp>
   </PropertyGroup>
 
   
   <Import Condition=" '$(_ExtrasHasDesktopSdk)' != 'true' " Project="$(MSBuildThisFileDirectory)..\Build\Workarounds.props" />
 
-  <Import Condition="'$(_ExtrasHasDesktopSdk)' == 'true' and !$(NETCoreSdkVersion.StartsWith('5'))" Project="$(MicrosoftWindowsDesktopSdkPath)\Microsoft.NET.Sdk.WindowsDesktop.props "/>
+  <Import Condition="'$(ExtrasUseWindowsDesktopApp)' != 'false'" Project="$(MicrosoftWindowsDesktopSdkPath)\Microsoft.NET.Sdk.WindowsDesktop.props" />
 
   <!-- TODO: Revisit once there's a way to control this directly -->
-  <ItemGroup Condition="'$(ExtrasUseWindowsDesktopApp)' != 'true'">
+  <ItemGroup Condition="'$(ExtrasUseWindowsDesktopApp)' != 'true' and '$(_ExtrasHasNet5OrGreaterSDK)' != 'true'">
     <FrameworkReference Remove="Microsoft.WindowsDesktop.App" />
   </ItemGroup>
 


### PR DESCRIPTION
Don't include Microsoft.NET.Sdk.WindowsDesktop.props when using .net 5.0 SDK because 5.0 SDK already includes it.
This prevents MSB4011 build warnings which can lead to nuget package restore errors preventing builds in CI environments

The fix should resolve the following build warnings

> warning MSB4011: "C:\Program Files\dotnet\sdk\5.0.100\Sdks\Microsoft.NET.Sdk.WindowsDesktop\targets\Microsoft.NET.Sdk.WindowsDesktop.props" cannot be imported again. It was already imported at "C:\Program Files\dotnet\sdk\5.0.100\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.props (147,3)". This is most likely a build authoring error. This subsequent import will be ignored.
